### PR TITLE
ci: re-enable depot runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,10 +19,7 @@ concurrency:
 jobs:
   check:
     name: check
-    # Temporarily disabled Depot runner selection due connectivity issues.
-    # Re-enable once Depot runners can reliably connect to the repository.
-    # runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-latest' || 'ubuntu-latest' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-latest' || 'ubuntu-latest' }}
     permissions:
       contents: read
       actions: write


### PR DESCRIPTION
Re-enable Depot runners for CI now that GitHub permissions have been fixed.

### What changed

- Uncommented the conditional `runs-on` expression in `.github/workflows/ci.yaml`
- Removed the temporary `runs-on: ubuntu-latest` override and the accompanying comments

The `check` job now uses `depot-ubuntu-latest` when the repo owner is `coder`, and falls back to `ubuntu-latest` for forks.

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh`_
