### PR TITLE
fix(connection): response-scoped notification barrier (fixes WaitGroup reuse panic)

### DIFF
--- a/acp_test.go
+++ b/acp_test.go
@@ -864,20 +864,9 @@ func TestConnectionFailsFastOnNotificationQueueOverflow(t *testing.T) {
 		t.Fatalf("expected overflow cancellation cause, got %v", cause)
 	}
 
-	// Let queued work drain and ensure waitgroup accounting remains balanced.
+	// Let queued work drain and ensure the notification barrier remains balanced.
 	close(releaseFirst)
-
-	drained := make(chan struct{})
-	go func() {
-		c.notificationWg.Wait()
-		close(drained)
-	}()
-
-	select {
-	case <-drained:
-	case <-time.After(1 * time.Second):
-		t.Fatalf("notification waitgroup did not drain after overflow")
-	}
+	waitForNotificationBarrierDrain(t, c, 1*time.Second)
 }
 
 // Test initialize method behavior

--- a/connection.go
+++ b/connection.go
@@ -30,8 +30,18 @@ type anyMessage struct {
 	Error   *RequestError    `json:"error,omitempty"`
 }
 
+type queuedNotification struct {
+	seq uint64
+	msg *anyMessage
+}
+
+type responseEnvelope struct {
+	msg                   anyMessage
+	notificationWatermark uint64
+}
+
 type pendingResponse struct {
-	ch chan anyMessage
+	ch chan responseEnvelope
 }
 
 type cancelRequestParams struct {
@@ -69,13 +79,16 @@ type Connection struct {
 
 	logger *slog.Logger
 
-	// notificationWg tracks in-flight notification handlers.  This ensures SendRequest waits
-	// for all notifications received before the response to complete processing.
-	notificationWg sync.WaitGroup
+	notifyMu sync.Mutex
+	// notifyCond coordinates response-scoped waits for sequential notification processing.
+	notifyCond *sync.Cond
+	// invariant: completedNotificationSeq <= lastEnqueuedNotificationSeq.
+	lastEnqueuedNotificationSeq uint64
+	completedNotificationSeq    uint64
 
 	// notificationQueue serializes notification processing to maintain order.
 	// It is bounded to keep memory usage predictable.
-	notificationQueue chan *anyMessage
+	notificationQueue chan queuedNotification
 }
 
 func NewConnection(handler MethodHandler, peerInput io.Writer, peerOutput io.Reader) *Connection {
@@ -92,8 +105,15 @@ func NewConnection(handler MethodHandler, peerInput io.Writer, peerOutput io.Rea
 		cancel:              cancel,
 		inboundCtx:          inboundCtx,
 		inboundCancel:       inboundCancel,
-		notificationQueue:   make(chan *anyMessage, defaultMaxQueuedNotifications),
+		notificationQueue:   make(chan queuedNotification, defaultMaxQueuedNotifications),
 	}
+	c.notifyCond = sync.NewCond(&c.notifyMu)
+	go func() {
+		<-c.ctx.Done()
+		c.notifyMu.Lock()
+		c.notifyCond.Broadcast()
+		c.notifyMu.Unlock()
+	}()
 	go c.sendCancelRequests()
 	go c.receive()
 	go c.processNotifications()
@@ -402,15 +422,27 @@ func (c *Connection) receive() {
 				continue
 			}
 
-			c.notificationWg.Add(1)
-
-			// Queue the notification for sequential processing.
+			// Queue the notification for sequential processing. The sequence number marks
+			// the response-scoped barrier boundary for requests that observe later responses.
 			m := msg
+			c.notifyMu.Lock()
+			c.lastEnqueuedNotificationSeq++
+			seq := c.lastEnqueuedNotificationSeq
 			select {
-			case c.notificationQueue <- &m:
+			case c.notificationQueue <- queuedNotification{seq: seq, msg: &m}:
+				c.notifyMu.Unlock()
 			default:
-				// Balance Add above when the message was not accepted.
-				c.notificationWg.Done()
+				if c.lastEnqueuedNotificationSeq != seq {
+					c.notifyMu.Unlock()
+					panic("notification sequence advanced while receive goroutine was queueing")
+				}
+				c.lastEnqueuedNotificationSeq--
+				// invariant: completedNotificationSeq never exceeds the highest accepted enqueue.
+				if c.completedNotificationSeq > c.lastEnqueuedNotificationSeq {
+					c.notifyMu.Unlock()
+					panic("completed notification sequence exceeded enqueued notification sequence")
+				}
+				c.notifyMu.Unlock()
 				c.loggerOrDefault().Error("failed to queue notification; closing connection", "err", errNotificationQueueOverflow, "capacity", cap(c.notificationQueue), "queued", len(c.notificationQueue))
 				c.shutdownReceive(errNotificationQueueOverflow)
 				return
@@ -440,20 +472,20 @@ func (c *Connection) shutdownReceive(cause error) {
 	// notification handlers may legitimately block until their context is canceled.
 	close(c.notificationQueue)
 
+	c.notifyMu.Lock()
+	finalEnqueuedSeq := c.lastEnqueuedNotificationSeq
+	if c.completedNotificationSeq > finalEnqueuedSeq {
+		c.notifyMu.Unlock()
+		panic("completed notification sequence exceeded final enqueued sequence during shutdown")
+	}
+	c.notifyMu.Unlock()
+
 	// Cancel inboundCtx after notifications finish, but ensure we don't leak forever if a
 	// handler blocks waiting for cancellation.
-	go func() {
-		done := make(chan struct{})
-		go func() {
-			c.notificationWg.Wait()
-			close(done)
-		}()
-		select {
-		case <-done:
-		case <-time.After(notificationQueueDrainTimeout):
-		}
+	go func(finalEnqueuedSeq uint64) {
+		c.waitForNotificationDrain(finalEnqueuedSeq, notificationQueueDrainTimeout)
 		c.inboundCancel(cause)
-	}()
+	}(finalEnqueuedSeq)
 
 	c.loggerOrDefault().Info("connection closed", "cause", cause.Error())
 }
@@ -461,9 +493,22 @@ func (c *Connection) shutdownReceive(cause error) {
 // processNotifications processes notifications sequentially to maintain order.
 // It terminates when notificationQueue is closed (e.g. on disconnect in receive()).
 func (c *Connection) processNotifications() {
-	for msg := range c.notificationQueue {
-		c.handleInbound(c.inboundCtx, msg)
-		c.notificationWg.Done()
+	for queued := range c.notificationQueue {
+		c.handleInbound(c.inboundCtx, queued.msg)
+
+		c.notifyMu.Lock()
+		expectedSeq := c.completedNotificationSeq + 1
+		if queued.seq != expectedSeq {
+			c.notifyMu.Unlock()
+			panic("notification sequence completed out of order")
+		}
+		c.completedNotificationSeq = queued.seq
+		if c.completedNotificationSeq > c.lastEnqueuedNotificationSeq {
+			c.notifyMu.Unlock()
+			panic("completed notification sequence exceeded enqueued notification sequence")
+		}
+		c.notifyCond.Broadcast()
+		c.notifyMu.Unlock()
 	}
 }
 
@@ -482,7 +527,14 @@ func (c *Connection) handleResponse(msg *anyMessage) {
 	c.mu.Unlock()
 
 	if pr != nil {
-		pr.ch <- *msg
+		c.notifyMu.Lock()
+		watermark := c.lastEnqueuedNotificationSeq
+		if c.completedNotificationSeq > watermark {
+			c.notifyMu.Unlock()
+			panic("completed notification sequence exceeded response watermark")
+		}
+		c.notifyMu.Unlock()
+		pr.ch <- responseEnvelope{msg: *msg, notificationWatermark: watermark}
 	}
 }
 
@@ -578,7 +630,7 @@ func SendRequest[T any](c *Connection, ctx context.Context, method string, param
 		return result, err
 	}
 
-	pr := &pendingResponse{ch: make(chan anyMessage, 1)}
+	pr := &pendingResponse{ch: make(chan responseEnvelope, 1)}
 	c.mu.Lock()
 	c.pending[idKey] = pr
 	c.mu.Unlock()
@@ -592,18 +644,16 @@ func SendRequest[T any](c *Connection, ctx context.Context, method string, param
 	if err != nil {
 		return result, err
 	}
-
-	// Wait for all notification handlers that were spawned before this response to complete
-	// processing.  This ensures that when a request returns, all notifications sent by the
-	// server before the response have been fully processed.
-	c.notificationWg.Wait()
-
-	if resp.Error != nil {
-		return result, resp.Error
+	if err := c.waitNotificationsUpTo(ctx, resp.notificationWatermark); err != nil {
+		return result, err
 	}
 
-	if len(resp.Result) > 0 {
-		if err := json.Unmarshal(resp.Result, &result); err != nil {
+	if resp.msg.Error != nil {
+		return result, resp.msg.Error
+	}
+
+	if len(resp.msg.Result) > 0 {
+		if err := json.Unmarshal(resp.msg.Result, &result); err != nil {
 			return result, NewInternalError(map[string]any{"error": err.Error()})
 		}
 	}
@@ -687,7 +737,7 @@ func (c *Connection) sendCancelRequest(idKey string) {
 	}
 }
 
-func (c *Connection) waitForResponse(ctx context.Context, pr *pendingResponse, idKey string) (anyMessage, error) {
+func (c *Connection) waitForResponse(ctx context.Context, pr *pendingResponse, idKey string) (responseEnvelope, error) {
 	peerDisconnectedErr := NewInternalError(map[string]any{"error": "peer disconnected before response"})
 
 	select {
@@ -699,7 +749,7 @@ func (c *Connection) waitForResponse(ctx context.Context, pr *pendingResponse, i
 		select {
 		case <-c.Done():
 			c.cleanupPending(idKey)
-			return anyMessage{}, peerDisconnectedErr
+			return responseEnvelope{}, peerDisconnectedErr
 		default:
 		}
 
@@ -711,12 +761,110 @@ func (c *Connection) waitForResponse(ctx context.Context, pr *pendingResponse, i
 			cause = ctx.Err()
 		}
 		if cause != nil {
-			return anyMessage{}, toReqErr(cause)
+			return responseEnvelope{}, toReqErr(cause)
 		}
-		return anyMessage{}, NewInternalError(map[string]any{"error": "request context ended without cause"})
+		return responseEnvelope{}, NewInternalError(map[string]any{"error": "request context ended without cause"})
 	case <-c.Done():
 		c.cleanupPending(idKey)
-		return anyMessage{}, peerDisconnectedErr
+		return responseEnvelope{}, peerDisconnectedErr
+	}
+}
+
+func (c *Connection) waitNotificationsUpTo(ctx context.Context, target uint64) error {
+	if target == 0 {
+		return nil
+	}
+
+	peerDisconnectedErr := NewInternalError(map[string]any{"error": "peer disconnected while waiting for pre-response notifications"})
+	stopWake := make(chan struct{})
+	defer close(stopWake)
+
+	c.notifyMu.Lock()
+	defer c.notifyMu.Unlock()
+	if target > c.lastEnqueuedNotificationSeq {
+		panic("response watermark exceeded last enqueued notification sequence")
+	}
+
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-stopWake:
+			return
+		}
+		c.notifyMu.Lock()
+		c.notifyCond.Broadcast()
+		c.notifyMu.Unlock()
+	}()
+
+	for c.completedNotificationSeq < target {
+		if c.completedNotificationSeq > c.lastEnqueuedNotificationSeq {
+			panic("completed notification sequence exceeded enqueued notification sequence while waiting")
+		}
+
+		select {
+		case <-c.Done():
+			return peerDisconnectedErr
+		default:
+		}
+		select {
+		case <-ctx.Done():
+			select {
+			case <-c.Done():
+				return peerDisconnectedErr
+			default:
+			}
+			cause := context.Cause(ctx)
+			if cause == nil {
+				cause = ctx.Err()
+			}
+			if cause != nil {
+				return toReqErr(cause)
+			}
+			return NewInternalError(map[string]any{"error": "request context ended without cause while waiting for notifications"})
+		default:
+		}
+
+		c.notifyCond.Wait()
+	}
+	return nil
+}
+
+func (c *Connection) waitForNotificationDrain(target uint64, timeout time.Duration) {
+	if target == 0 {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	stopWake := make(chan struct{})
+	defer close(stopWake)
+
+	c.notifyMu.Lock()
+	defer c.notifyMu.Unlock()
+	if target > c.lastEnqueuedNotificationSeq {
+		panic("drain target exceeded last enqueued notification sequence")
+	}
+
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-stopWake:
+			return
+		}
+		c.notifyMu.Lock()
+		c.notifyCond.Broadcast()
+		c.notifyMu.Unlock()
+	}()
+
+	for c.completedNotificationSeq < target {
+		if c.completedNotificationSeq > c.lastEnqueuedNotificationSeq {
+			panic("completed notification sequence exceeded enqueued notification sequence during drain")
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		c.notifyCond.Wait()
 	}
 }
 
@@ -733,7 +881,7 @@ func (c *Connection) SendRequestNoResult(ctx context.Context, method string, par
 		return err
 	}
 
-	pr := &pendingResponse{ch: make(chan anyMessage, 1)}
+	pr := &pendingResponse{ch: make(chan responseEnvelope, 1)}
 	c.mu.Lock()
 	c.pending[idKey] = pr
 	c.mu.Unlock()
@@ -747,14 +895,12 @@ func (c *Connection) SendRequestNoResult(ctx context.Context, method string, par
 	if err != nil {
 		return err
 	}
+	if err := c.waitNotificationsUpTo(ctx, resp.notificationWatermark); err != nil {
+		return err
+	}
 
-	// Wait for all notification handlers that were spawned before this response to complete
-	// processing.  This ensures that when a request returns, all notifications sent by the
-	// server before the response have been fully processed.
-	c.notificationWg.Wait()
-
-	if resp.Error != nil {
-		return resp.Error
+	if resp.msg.Error != nil {
+		return resp.msg.Error
 	}
 	return nil
 }

--- a/connection_cancel_test.go
+++ b/connection_cancel_test.go
@@ -631,7 +631,7 @@ func TestConnectionWaitForResponse_PeerDisconnectWinsOverDerivedContextCancel(t 
 		}
 
 		idKey := fmt.Sprintf("id-%d", i)
-		pr := &pendingResponse{ch: make(chan anyMessage)}
+		pr := &pendingResponse{ch: make(chan responseEnvelope)}
 		c.pending[idKey] = pr
 
 		requestCtx, requestCancel := context.WithCancel(baseCtx)

--- a/connection_notification_barrier_test.go
+++ b/connection_notification_barrier_test.go
@@ -1,0 +1,409 @@
+package acp
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func newNotificationBarrierTestPair(t *testing.T, client Client, agent Agent) (*ClientSideConnection, *AgentSideConnection) {
+	t.Helper()
+
+	c2aR, c2aW := io.Pipe()
+	a2cR, a2cW := io.Pipe()
+
+	clientConn := NewClientSideConnection(client, c2aW, a2cR)
+	agentConn := NewAgentSideConnection(agent, a2cW, c2aR)
+
+	t.Cleanup(func() {
+		_ = c2aR.Close()
+		_ = c2aW.Close()
+		_ = a2cR.Close()
+		_ = a2cW.Close()
+	})
+
+	return clientConn, agentConn
+}
+
+func testLoadSessionRequest(sessionID string) LoadSessionRequest {
+	return LoadSessionRequest{
+		SessionId:  SessionId(sessionID),
+		Cwd:        "/",
+		McpServers: []McpServer{},
+	}
+}
+
+func testSessionUpdate(sessionID SessionId, seq int) SessionNotification {
+	return SessionNotification{
+		Meta:      map[string]any{"seq": seq},
+		SessionId: sessionID,
+		Update: SessionUpdate{
+			AgentMessageChunk: &SessionUpdateAgentMessageChunk{
+				Content: TextBlock(fmt.Sprintf("chunk-%d", seq)),
+			},
+		},
+	}
+}
+
+func notificationSequence(t *testing.T, n SessionNotification) int {
+	t.Helper()
+
+	value, ok := n.Meta["seq"]
+	if !ok {
+		t.Fatalf("notification missing seq metadata")
+	}
+
+	switch v := value.(type) {
+	case float64:
+		return int(v)
+	case int:
+		return v
+	default:
+		t.Fatalf("unexpected seq metadata type %T", value)
+		return 0
+	}
+}
+
+func waitForPendingRequests(t *testing.T, c *Connection, want int, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		c.mu.Lock()
+		got := len(c.pending)
+		c.mu.Unlock()
+		if got == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	c.mu.Lock()
+	got := len(c.pending)
+	c.mu.Unlock()
+	t.Fatalf("pending requests = %d, want %d", got, want)
+}
+
+func waitForNotificationBarrierDrain(t *testing.T, c *Connection, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		c.notifyMu.Lock()
+		completed := c.completedNotificationSeq
+		enqueued := c.lastEnqueuedNotificationSeq
+		c.notifyMu.Unlock()
+		if completed >= enqueued {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	c.notifyMu.Lock()
+	completed := c.completedNotificationSeq
+	enqueued := c.lastEnqueuedNotificationSeq
+	c.notifyMu.Unlock()
+	t.Fatalf("notification barrier did not drain: completed=%d enqueued=%d", completed, enqueued)
+}
+
+func TestSendRequest_WaitsForPreResponseNotification(t *testing.T) {
+	handlerStarted := make(chan struct{})
+	handlerFinished := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	allowResponse := make(chan struct{})
+
+	client := &clientFuncs{
+		SessionUpdateFunc: func(context.Context, SessionNotification) error {
+			close(handlerStarted)
+			<-releaseHandler
+			close(handlerFinished)
+			return nil
+		},
+	}
+
+	var agentConn *AgentSideConnection
+	agent := agentFuncs{
+		LoadSessionFunc: func(ctx context.Context, req LoadSessionRequest) (LoadSessionResponse, error) {
+			if err := agentConn.SessionUpdate(ctx, testSessionUpdate(req.SessionId, 1)); err != nil {
+				return LoadSessionResponse{}, err
+			}
+			<-allowResponse
+			return LoadSessionResponse{}, nil
+		},
+	}
+
+	clientConn, createdAgentConn := newNotificationBarrierTestPair(t, client, agent)
+	agentConn = createdAgentConn
+
+	resultCh := make(chan error, 1)
+	go func() {
+		_, err := clientConn.LoadSession(context.Background(), testLoadSessionRequest("pre-response"))
+		resultCh <- err
+	}()
+
+	select {
+	case <-handlerStarted:
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for pre-response notification handler to start")
+	}
+
+	close(allowResponse)
+	waitForPendingRequests(t, clientConn.conn, 0, time.Second)
+
+	select {
+	case err := <-resultCh:
+		t.Fatalf("LoadSession returned before notification handler finished: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(releaseHandler)
+
+	select {
+	case <-handlerFinished:
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for pre-response notification handler to finish")
+	}
+
+	select {
+	case err := <-resultCh:
+		if err != nil {
+			t.Fatalf("LoadSession returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for LoadSession to return after notification handler finished")
+	}
+}
+
+func TestSendRequest_DoesNotWaitForPostResponseNotification(t *testing.T) {
+	handlerStarted := make(chan struct{})
+	handlerFinished := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	notificationErrCh := make(chan error, 1)
+
+	client := &clientFuncs{
+		SessionUpdateFunc: func(context.Context, SessionNotification) error {
+			close(handlerStarted)
+			<-releaseHandler
+			close(handlerFinished)
+			return nil
+		},
+	}
+
+	var agentConn *AgentSideConnection
+	agent := agentFuncs{
+		LoadSessionFunc: func(context.Context, LoadSessionRequest) (LoadSessionResponse, error) {
+			go func() {
+				time.Sleep(25 * time.Millisecond)
+				notificationErrCh <- agentConn.SessionUpdate(context.Background(), testSessionUpdate(SessionId("post-response"), 1))
+			}()
+			return LoadSessionResponse{}, nil
+		},
+	}
+
+	clientConn, createdAgentConn := newNotificationBarrierTestPair(t, client, agent)
+	agentConn = createdAgentConn
+
+	resultCh := make(chan error, 1)
+	go func() {
+		_, err := clientConn.LoadSession(context.Background(), testLoadSessionRequest("post-response"))
+		resultCh <- err
+	}()
+
+	select {
+	case err := <-resultCh:
+		if err != nil {
+			t.Fatalf("LoadSession returned error: %v", err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatalf("LoadSession blocked on post-response notification")
+	}
+
+	select {
+	case <-handlerStarted:
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for post-response notification handler to start")
+	}
+
+	select {
+	case err := <-notificationErrCh:
+		if err != nil {
+			t.Fatalf("post-response notification send failed: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for post-response notification send to complete")
+	}
+
+	select {
+	case <-handlerFinished:
+		t.Fatalf("post-response notification handler finished before release")
+	default:
+	}
+
+	close(releaseHandler)
+
+	select {
+	case <-handlerFinished:
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for post-response notification handler to finish")
+	}
+
+	select {
+	case err := <-notificationErrCh:
+		if err != nil {
+			t.Fatalf("post-response notification send failed: %v", err)
+		}
+	default:
+	}
+}
+
+func TestSendRequest_ConcurrentRequestsDoNotPanic(t *testing.T) {
+	const concurrentRequests = 32
+	const notificationsPerRequest = 2
+
+	client := &clientFuncs{
+		SessionUpdateFunc: func(context.Context, SessionNotification) error {
+			time.Sleep(2 * time.Millisecond)
+			return nil
+		},
+	}
+
+	var agentConn *AgentSideConnection
+	agent := agentFuncs{
+		LoadSessionFunc: func(ctx context.Context, req LoadSessionRequest) (LoadSessionResponse, error) {
+			for i := 0; i < notificationsPerRequest; i++ {
+				if err := agentConn.SessionUpdate(ctx, testSessionUpdate(req.SessionId, i)); err != nil {
+					return LoadSessionResponse{}, err
+				}
+				time.Sleep(time.Millisecond)
+			}
+			return LoadSessionResponse{}, nil
+		},
+	}
+
+	clientConn, createdAgentConn := newNotificationBarrierTestPair(t, client, agent)
+	agentConn = createdAgentConn
+
+	start := make(chan struct{})
+	errCh := make(chan error, concurrentRequests)
+	var wg sync.WaitGroup
+
+	for i := 0; i < concurrentRequests; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			_, err := clientConn.LoadSession(ctx, testLoadSessionRequest(fmt.Sprintf("concurrent-%d", i)))
+			errCh <- err
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("LoadSession returned error: %v", err)
+		}
+	}
+}
+
+func TestLoadSession_NotificationReplayOrdering(t *testing.T) {
+	const replayUpdates = 5
+
+	var (
+		mu   sync.Mutex
+		seen []int
+	)
+
+	client := &clientFuncs{
+		SessionUpdateFunc: func(_ context.Context, n SessionNotification) error {
+			mu.Lock()
+			seen = append(seen, notificationSequence(t, n))
+			mu.Unlock()
+			return nil
+		},
+	}
+
+	var agentConn *AgentSideConnection
+	agent := agentFuncs{
+		LoadSessionFunc: func(ctx context.Context, req LoadSessionRequest) (LoadSessionResponse, error) {
+			for i := 0; i < replayUpdates; i++ {
+				if err := agentConn.SessionUpdate(ctx, testSessionUpdate(req.SessionId, i)); err != nil {
+					return LoadSessionResponse{}, err
+				}
+			}
+			return LoadSessionResponse{}, nil
+		},
+	}
+
+	clientConn, createdAgentConn := newNotificationBarrierTestPair(t, client, agent)
+	agentConn = createdAgentConn
+
+	if _, err := clientConn.LoadSession(context.Background(), testLoadSessionRequest("replay-order")); err != nil {
+		t.Fatalf("LoadSession returned error: %v", err)
+	}
+
+	mu.Lock()
+	got := append([]int(nil), seen...)
+	mu.Unlock()
+
+	if len(got) != replayUpdates {
+		t.Fatalf("replayed notifications = %d, want %d", len(got), replayUpdates)
+	}
+	for i, seq := range got {
+		if seq != i {
+			t.Fatalf("replayed notifications out of order: got %v", got)
+		}
+	}
+}
+
+func TestShutdownDrainsNotifications_WithBarrier(t *testing.T) {
+	handlerStarted := make(chan struct{})
+	var handlerCompleted atomic.Bool
+
+	client := &clientFuncs{
+		SessionUpdateFunc: func(context.Context, SessionNotification) error {
+			close(handlerStarted)
+			time.Sleep(50 * time.Millisecond)
+			handlerCompleted.Store(true)
+			return nil
+		},
+	}
+
+	clientConn, agentConn := newNotificationBarrierTestPair(t, client, agentFuncs{})
+
+	if err := agentConn.SessionUpdate(context.Background(), testSessionUpdate(SessionId("shutdown"), 1)); err != nil {
+		t.Fatalf("SessionUpdate returned error: %v", err)
+	}
+
+	select {
+	case <-handlerStarted:
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for shutdown notification handler to start")
+	}
+
+	if writer, ok := agentConn.conn.w.(*io.PipeWriter); ok {
+		_ = writer.Close()
+	} else {
+		t.Fatalf("expected io.PipeWriter, got %T", agentConn.conn.w)
+	}
+
+	select {
+	case <-clientConn.conn.inboundCtx.Done():
+		if !handlerCompleted.Load() {
+			t.Fatalf("shutdown canceled inbound context before notification handler completed")
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for shutdown to drain notifications")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a `sync: WaitGroup is reused before previous Wait has returned` panic in
`Connection` under concurrent requests that overlap with inbound notifications
(for example, `ClientSideConnection.LoadSession` replaying `session/update`
notifications during a resumed session).

The root cause is that `SendRequest[T]` / `SendRequestNoResult` were calling
`c.notificationWg.Wait()` on a shared `sync.WaitGroup` after every response.
With overlapping requests, two waiters could race the counter's reuse and
trigger the runtime panic. The shared counter also could not express the
intended "wait only for notifications that were enqueued before this response
was observed" semantics.

## What changed

### Runtime (`connection.go`)

- Removed the shared `notificationWg` barrier from the request / shutdown path.
- Added a response-scoped, monotonic notification-sequence barrier:
  - `notifyMu`, `notifyCond`
  - `lastEnqueuedNotificationSeq` (advanced under `notifyMu` when a
    notification is accepted into the queue, rolled back on queue overflow)
  - `completedNotificationSeq` (advanced under `notifyMu` after each handler
    returns; broadcast on `notifyCond`)
  - invariant: `completedNotificationSeq <= lastEnqueuedNotificationSeq`
    (runtime-checked with a `panic` on impossible states)
- Replaced `chan *anyMessage` with `chan queuedNotification` so the single
  consumer knows which sequence it is completing.
- Added a `responseEnvelope` so `handleResponse` snapshots the notification
  watermark in the receive goroutine **before** waking the waiter, giving each
  response a response-scoped barrier target.
- `SendRequest[T]` / `SendRequestNoResult` now wait via
  `waitNotificationsUpTo(ctx, target)` using `notifyCond` in a re-checking
  loop, honoring `ctx.Done()` and the connection context. If the connection
  is canceled while a request is waiting for its pre-response barrier, it now
  returns a connection error instead of blocking indefinitely (intentional
  behavior change — previously the shared `WaitGroup` could deadlock here).
- `shutdownReceive` drains to the final enqueued sequence using the same cond,
  keeping the existing 5s timeout.

Notification order is still preserved by the single-consumer
`processNotifications` goroutine. Public API is unchanged. No generated files
were touched.

### Tests

- New file `connection_notification_barrier_test.go` adds regression coverage:
  - `TestSendRequest_WaitsForPreResponseNotification` — `LoadSession` blocks
    until the pre-response `session/update` handler finishes.
  - `TestSendRequest_DoesNotWaitForPostResponseNotification` — `LoadSession`
    returns promptly even while a post-response notification handler is still
    blocked.
  - `TestSendRequest_ConcurrentRequestsDoNotPanic` — overlapping requests +
    notifications; this is the previously-panicking scenario.
  - `TestLoadSession_NotificationReplayOrdering` — resumed-session replay
    ordering across multiple `session/update` notifications.
  - `TestShutdownDrainsNotifications_WithBarrier` — shutdown drains through
    the final queued notification.
- Incidental updates:
  - `acp_test.go` queue-overflow test migrated to the new barrier primitive.
  - `connection_cancel_test.go` adjusted for the new `responseEnvelope`
    channel type.

## Validation

Run locally on this branch before opening the PR:

| Command | Result |
| --- | --- |
| `go test ./...` | `ok github.com/coder/acp-go-sdk 1.314s` |
| `go test ./... -race -count=20 -run 'TestSendRequest_ConcurrentRequestsDoNotPanic\|TestLoadSession_NotificationReplayOrdering\|TestSendRequest_WaitsForPreResponseNotification\|TestSendRequest_DoesNotWaitForPostResponseNotification\|TestShutdownDrainsNotifications_WithBarrier'` | `ok 8.116s` (100 runs of the 5 regressions under `-race`) |
| `make test` (library tests + example builds) | PASS |
| `grep -rn notificationWg --include='*.go' .` | 0 hits |

## Diff stat

```
 acp_test.go                             |  15 +-
 connection.go                           | 246 +++++++++++++++----
 connection_cancel_test.go               |   2 +-
 connection_notification_barrier_test.go | 409 ++++++++++++++++++++++++++++++++
 4 files changed, 608 insertions(+), 64 deletions(-)
```

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Fix notification wait race in `acp-go-sdk`

## Goal
Fix the upstream SDK bug in `connection.go` that can panic with `sync: WaitGroup is reused before previous Wait has returned`, while preserving the intended behavior that `SendRequest` only waits for notifications that were received before the matching response was observed.

## Verified repository context
- `Connection` currently uses a shared `notificationWg` in `connection.go` across the inbound notification path.
- `receive()` increments notification tracking when it accepts a notification, `processNotifications()` decrements it after serial handler execution, and both `SendRequest[T]()` / `SendRequestNoResult()` wait after `waitForResponse()` returns.
- `shutdownReceive()` also drains pending notifications before canceling inbound work.
- Existing tests cover concurrent requests, notifications, shutdown draining, and queue overflow, but they do not currently lock in the response-vs-notification interleaving that mirrors `ClientSideConnection.LoadSession` replay on resumed sessions.
- The generated wrappers in `client_gen.go` / `agent_gen.go` appear to route through the shared connection helpers, so the fix should stay centered in `connection.go` plus tests.

<details>
<summary>Design constraint that should drive the fix</summary>

A plain shared counter/cond replacement is not enough by itself. The fix needs a response-scoped barrier:
- notification order must still be preserved by the existing queue,
- `SendRequest` must wait for notifications enqueued before the response boundary,
- and it must not be forced to wait for notifications that arrive after that boundary.

That means the notification watermark has to be captured in the receive path when the response is observed, then waited on later by request/shutdown code.
</details>

## Phase 1 — Build a repo-local reproducible setup
1. Add an SDK-only regression harness using the repo’s existing connection test style (pipes/fake peer helpers), so validation does not depend on the unavailable `reviewfixer` source tree.
2. Cover two levels of reproduction:
   - a raw `Connection` / `SendRequest` interleaving test that can precisely gate notifications and the response,
   - and a higher-level `ClientSideConnection.LoadSession` replay scenario that mimics resumed-session `session/update` notifications around `session/load`.
3. Use channels or other deterministic gates to force the important boundaries:
   - a notification that is enqueued before the response but finishes later,
   - and a notification that arrives after the response boundary.
4. Add explicit regression assertions for both semantics:
   - pre-response notifications block the request from returning,
   - post-response notifications do not block the request from returning.
5. Add a repeatable stress target for the private-consumer-shaped scenario (for example, a focused `go test ... -count=100` run) so the old panic shape can be exercised without external repositories.

**Quality gate:** before the refactor is considered done, the repo contains a self-contained test setup that reproduces the session/load replay conditions inside `acp-go-sdk` itself.

## Phase 2 — Replace the shared WaitGroup with an ordered notification barrier
1. Refactor `connection.go` to remove `notificationWg` from the response/shutdown synchronization path.
2. Introduce response-scoped barrier state on `Connection`, implemented with a mutex/cond plus monotonic sequence counters, e.g.:
   - `lastEnqueuedNotificationSeq`
   - `completedNotificationSeq`
   - a queued notification wrapper that carries both the message and its sequence number.
3. In `receive()`:
   - assign a monotonically increasing sequence number when a notification is successfully accepted into the notification queue,
   - snapshot `lastEnqueuedNotificationSeq` when a response is observed,
   - and attach that snapshot to the response handed to the waiting request path.
4. In `processNotifications()`:
   - keep the existing serial queue semantics,
   - advance `completedNotificationSeq` only after the handler finishes,
   - and broadcast the cond so any waiting request/shutdown path can re-check its target.
5. In `SendRequest[T]()` and `SendRequestNoResult()`:
   - wait until `completedNotificationSeq` reaches the response’s captured target sequence,
   - then decode/return the response,
   - without waiting on notifications that arrived after the response boundary.
6. In `shutdownReceive()`:
   - reuse the same barrier instead of a second drain primitive,
   - snapshot the final queued notification sequence only after no more notifications can be enqueued,
   - and keep the existing timeout-based drain behavior.
7. Add defensive internal invariants/comments around the new barrier state so the monotonic sequence assumptions stay obvious during future changes (for example: completed seq never exceeds last enqueued seq, and waiters always re-check in a loop).

**Quality gate:** the old shared WaitGroup no longer participates in request/shutdown notification draining, and the new barrier preserves the intended “received before response” ordering contract.

## Phase 3 — Update and extend tests around the new barrier
1. Add focused regression tests alongside the existing connection tests (either in `acp_test.go` or a new narrow `*_test.go` file) for:
   - raw interleaving of notifications and responses,
   - `ClientSideConnection.LoadSession` replay behavior,
   - and repeated concurrent runs that previously risked the panic.
2. Update any existing tests that reach into `notificationWg` directly so they assert observable behavior instead of the removed primitive.
3. Keep generated wrappers unchanged unless a compile-time type update is unavoidable; the behavior change should remain centralized in `connection.go`.
4. Document in test names/comments why the previous WaitGroup design was invalid: an open-ended receive loop cannot safely use a shared WaitGroup to model a response-specific notification boundary.

**Quality gate:** new regression tests are stable under repeated runs, and existing shutdown/overflow/concurrency tests still validate the same external behavior.

## Validation
- Run focused regression coverage while iterating, especially the new connection/load-session tests.
- Run repeated targeted stress passes for the interleaving scenario (for example `go test ./... -run '<new regression names>' -count=100`).
- Run the full suite with `go test ./...`.
- Run `make test` so example binaries continue to compile alongside the library tests.
- If practical in the environment, run `go test ./... -race` for the touched package or full repo as an additional concurrency check.

## Dogfooding / self-verification
1. Treat the new SDK-only `LoadSession` replay test as the permanent reproducible setup for this issue; do not rely on the private consumer repository.
2. Record terminal evidence for reviewers while validating the fix:
   - one recording of the focused replay/interleaving regression run,
   - one recording of the repeated stress run,
   - and one recording or transcript of the final suite command(s).
3. Capture screenshots of:
   - the targeted replay test passing without panic,
   - and the full validation run succeeding.
4. If a temporary standalone harness is useful during implementation, keep it test-local or remove it before finishing so the committed reproducible setup is the regression test suite itself.

## Acceptance criteria
- The fix lives in `acp-go-sdk`, not in a downstream consumer workaround.
- `SendRequest[T]()` and `SendRequestNoResult()` wait only for notifications queued before the matching response was observed.
- Notification handling remains serialized in queue order.
- `shutdownReceive()` drains through the final queued notification sequence and keeps timeout behavior.
- The SDK has a repo-local regression setup covering both raw connection interleaving and a `ClientSideConnection.LoadSession` replay scenario.
- `go test ./...` and `make test` pass, with targeted repeated runs showing the panic no longer occurs in the reproducible setup.

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `anthropic:claude-opus-4-7` • Thinking: `max`_
