### PR TITLE
[codex] Add communique release notes workflow

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -34,3 +34,17 @@ updates:
       - dependency-name: "*"
         update-types:
           - version-update:semver-patch
+
+  - package-ecosystem: nix
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      time: "06:00"
+      timezone: "America/Chicago"
+    labels: []
+    commit-message:
+      prefix: "chore"
+    groups:
+      nix:
+        patterns:
+          - "*"

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -1,0 +1,71 @@
+name: Release Notes
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: write
+
+jobs:
+  release-notes:
+    name: release-notes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate release inputs
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          : "${ANTHROPIC_API_KEY:?ANTHROPIC_API_KEY secret is required}"
+          : "${GITHUB_TOKEN:?GITHUB_TOKEN is required}"
+          : "${RELEASE_TAG:?release tag is required}"
+
+          case "$RELEASE_TAG" in
+            v*) ;;
+            *)
+              echo "release tag must start with 'v': $RELEASE_TAG" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Install communique
+        env:
+          COMMUNIQUE_SHA256: 01a6a8b49e635a5a209fdaf6c7b2e976374debc2db1c846c033f567fdba0d86c
+          COMMUNIQUE_VERSION: v1.1.2
+        run: |
+          set -euo pipefail
+
+          archive="communique-x86_64-unknown-linux-musl.tar.gz"
+          url="https://github.com/jdx/communique/releases/download/${COMMUNIQUE_VERSION}/${archive}"
+          tmp="$(mktemp -d)"
+          trap 'rm -rf "$tmp"' EXIT
+
+          curl --fail --location --show-error --silent "$url" --output "$tmp/$archive"
+          echo "${COMMUNIQUE_SHA256}  $tmp/$archive" | sha256sum --check -
+          tar -xzf "$tmp/$archive" -C "$tmp"
+          test -x "$tmp/communique"
+
+          install -m 0755 "$tmp/communique" /usr/local/bin/communique
+          communique --version
+
+      - name: Generate GitHub release notes
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          communique generate "$RELEASE_TAG" --github-release --repo "${{ github.repository }}"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,6 +12,8 @@ code, helper APIs, and library version remain in sync.
 - Nix is required for `make fmt` and `make check` (they invoke `nix fmt` and
   `nix flake check`). Use `nix develop` or an equivalent environment before
   running these targets.
+- The repository must have an Actions secret named `ANTHROPIC_API_KEY` so the
+  release-notes workflow can update GitHub Release bodies after publication.
 
 ## Bump the Schema Version
 
@@ -70,6 +72,10 @@ file agree before you publish.
 1. Create a GitHub release for the tag. Include a summary of notable changes and
    reference the upstream ACP schema version.
 
+After the GitHub release is published, CI runs `communique` and replaces the
+release body with generated notes. The workflow requires a `v*` release tag and
+the `ANTHROPIC_API_KEY` Actions secret.
+
 Consumers rely on the `vX.Y.Z` semver tag for `go get`, so ensure the tag is
 pushed before announcing the release.
 
@@ -77,6 +83,8 @@ pushed before announcing the release.
 
 - If the new schema introduces breaking changes, update examples and docs in
   the same commit.
+- Release-note automation updates GitHub Release bodies only; it does not
+  maintain a `CHANGELOG.md`.
 - The helper uses a repository-local Go build cache (`.gocache`) to avoid
   sandbox restrictions in CI and local development. You can delete it with
   `rm -rf .gocache` if needed.

--- a/communique.toml
+++ b/communique.toml
@@ -1,0 +1,15 @@
+context = """
+acp-go-sdk is the Go SDK for the Agent Client Protocol (ACP). Releases track ACP schema tags from agentclientprotocol/agent-client-protocol and should help Go SDK users understand what changed in generated protocol APIs, helper APIs, examples, and compatibility.
+
+Generated Go files with the _gen.go suffix come from schema updates. When schema-aligned releases change generated APIs, explain the user-visible Go surface and migration impact rather than restating internal generator mechanics.
+
+Primary readers are Go developers integrating ACP agents and clients. Call out breaking changes, behavior changes, dependency or tooling requirements, schema/version alignment, and example updates.
+"""
+
+system_extra = """
+Write direct, practical release notes for SDK users.
+Lead with what changed and why it matters.
+Keep sections concise and avoid marketing language.
+Prefer concrete migration guidance when APIs or generated types changed.
+Do not invent changes that are not supported by the commits, pull requests, or diffs.
+"""


### PR DESCRIPTION
## Summary
- add a release.published GitHub Actions workflow that installs pinned communique v1.1.2, validates required secrets/tag inputs, and updates the GitHub Release body
- add communique project/style guidance for acp-go-sdk release notes
- document the ANTHROPIC_API_KEY release prerequisite and post-publish release-note rewrite
- include the existing Dependabot nix ecosystem update in the committed scope

## Validation
- nix develop .# --command actionlint .github/workflows/release-notes.yaml
- nix develop .# --command treefmt --fail-on-change
- nix flake check
- verified the pinned communique archive download and SHA256 locally