### PR TITLE
Add configurable notification queue size via ConnectionOption

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -17,12 +17,13 @@ type AgentSideConnection struct {
 }
 
 // NewAgentSideConnection creates a new agent-side connection bound to the
-// provided Agent implementation.
-func NewAgentSideConnection(agent Agent, peerInput io.Writer, peerOutput io.Reader) *AgentSideConnection {
+// provided Agent implementation. Optional ConnectionOption values configure
+// the underlying connection (e.g., WithMaxQueuedNotifications).
+func NewAgentSideConnection(agent Agent, peerInput io.Writer, peerOutput io.Reader, opts ...ConnectionOption) *AgentSideConnection {
 	asc := &AgentSideConnection{}
 	asc.agent = agent
 	asc.sessionCancels = make(map[string]context.CancelFunc)
-	asc.conn = NewConnection(asc.handleWithExtensions, peerInput, peerOutput)
+	asc.conn = NewConnection(asc.handleWithExtensions, peerInput, peerOutput, opts...)
 	return asc
 }
 

--- a/client.go
+++ b/client.go
@@ -12,11 +12,12 @@ type ClientSideConnection struct {
 }
 
 // NewClientSideConnection creates a new client-side connection bound to the
-// provided Client implementation.
-func NewClientSideConnection(client Client, peerInput io.Writer, peerOutput io.Reader) *ClientSideConnection {
+// provided Client implementation. Optional ConnectionOption values configure
+// the underlying connection (e.g., WithMaxQueuedNotifications).
+func NewClientSideConnection(client Client, peerInput io.Writer, peerOutput io.Reader, opts ...ConnectionOption) *ClientSideConnection {
 	csc := &ClientSideConnection{}
 	csc.client = client
-	csc.conn = NewConnection(csc.handleWithExtensions, peerInput, peerOutput)
+	csc.conn = NewConnection(csc.handleWithExtensions, peerInput, peerOutput, opts...)
 	return csc
 }
 

--- a/connection.go
+++ b/connection.go
@@ -91,7 +91,34 @@ type Connection struct {
 	notificationQueue chan queuedNotification
 }
 
-func NewConnection(handler MethodHandler, peerInput io.Writer, peerOutput io.Reader) *Connection {
+// ConnectionOption configures optional parameters for a Connection.
+type ConnectionOption func(*connectionConfig)
+
+type connectionConfig struct {
+	maxQueuedNotifications int
+}
+
+// WithMaxQueuedNotifications sets the maximum number of queued notifications
+// before the connection is closed with a notification queue overflow error.
+// The default is 1024. Increase this value when multiplexing many concurrent
+// sessions over a single connection, as the combined notification rate may
+// exceed the processing speed of the single-threaded notification consumer.
+func WithMaxQueuedNotifications(n int) ConnectionOption {
+	return func(cfg *connectionConfig) {
+		if n > 0 {
+			cfg.maxQueuedNotifications = n
+		}
+	}
+}
+
+func NewConnection(handler MethodHandler, peerInput io.Writer, peerOutput io.Reader, opts ...ConnectionOption) *Connection {
+	cfg := connectionConfig{
+		maxQueuedNotifications: defaultMaxQueuedNotifications,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	ctx, cancel := context.WithCancelCause(context.Background())
 	inboundCtx, inboundCancel := context.WithCancelCause(context.Background())
 	c := &Connection{
@@ -105,7 +132,7 @@ func NewConnection(handler MethodHandler, peerInput io.Writer, peerOutput io.Rea
 		cancel:              cancel,
 		inboundCtx:          inboundCtx,
 		inboundCancel:       inboundCancel,
-		notificationQueue:   make(chan queuedNotification, defaultMaxQueuedNotifications),
+		notificationQueue:   make(chan queuedNotification, cfg.maxQueuedNotifications),
 	}
 	c.notifyCond = sync.NewCond(&c.notifyMu)
 	go func() {

--- a/connection_queue_size_test.go
+++ b/connection_queue_size_test.go
@@ -2,7 +2,6 @@ package acp
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"sync"
 	"testing"
@@ -149,5 +148,4 @@ func TestLargerQueue_SurvivesNotificationBurst(t *testing.T) {
 	if got != burstSize {
 		t.Fatalf("received %d notifications, want %d", got, burstSize)
 	}
-	_ = fmt.Sprintf("") // use fmt
 }

--- a/connection_queue_size_test.go
+++ b/connection_queue_size_test.go
@@ -1,0 +1,153 @@
+package acp
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestWithMaxQueuedNotifications_DefaultSize(t *testing.T) {
+	// Verify default queue capacity without options.
+	c2aR, c2aW := io.Pipe()
+	a2cR, a2cW := io.Pipe()
+	t.Cleanup(func() {
+		_ = c2aR.Close()
+		_ = c2aW.Close()
+		_ = a2cR.Close()
+		_ = a2cW.Close()
+	})
+
+	client := &clientFuncs{}
+	csc := NewClientSideConnection(client, c2aW, a2cR)
+
+	if cap(csc.conn.notificationQueue) != defaultMaxQueuedNotifications {
+		t.Fatalf("default queue capacity = %d, want %d", cap(csc.conn.notificationQueue), defaultMaxQueuedNotifications)
+	}
+}
+
+func TestWithMaxQueuedNotifications_CustomSize(t *testing.T) {
+	c2aR, c2aW := io.Pipe()
+	a2cR, a2cW := io.Pipe()
+	t.Cleanup(func() {
+		_ = c2aR.Close()
+		_ = c2aW.Close()
+		_ = a2cR.Close()
+		_ = a2cW.Close()
+	})
+
+	const customSize = 8192
+	client := &clientFuncs{}
+	csc := NewClientSideConnection(client, c2aW, a2cR, WithMaxQueuedNotifications(customSize))
+
+	if cap(csc.conn.notificationQueue) != customSize {
+		t.Fatalf("custom queue capacity = %d, want %d", cap(csc.conn.notificationQueue), customSize)
+	}
+}
+
+func TestWithMaxQueuedNotifications_AgentSide(t *testing.T) {
+	c2aR, c2aW := io.Pipe()
+	a2cR, a2cW := io.Pipe()
+	t.Cleanup(func() {
+		_ = c2aR.Close()
+		_ = c2aW.Close()
+		_ = a2cR.Close()
+		_ = a2cW.Close()
+	})
+
+	const customSize = 4096
+	asc := NewAgentSideConnection(agentFuncs{}, a2cW, c2aR, WithMaxQueuedNotifications(customSize))
+
+	if cap(asc.conn.notificationQueue) != customSize {
+		t.Fatalf("agent queue capacity = %d, want %d", cap(asc.conn.notificationQueue), customSize)
+	}
+}
+
+func TestWithMaxQueuedNotifications_ZeroIgnored(t *testing.T) {
+	c2aR, c2aW := io.Pipe()
+	a2cR, a2cW := io.Pipe()
+	t.Cleanup(func() {
+		_ = c2aR.Close()
+		_ = c2aW.Close()
+		_ = a2cR.Close()
+		_ = a2cW.Close()
+	})
+
+	client := &clientFuncs{}
+	csc := NewClientSideConnection(client, c2aW, a2cR, WithMaxQueuedNotifications(0))
+
+	if cap(csc.conn.notificationQueue) != defaultMaxQueuedNotifications {
+		t.Fatalf("zero option should keep default: got %d, want %d", cap(csc.conn.notificationQueue), defaultMaxQueuedNotifications)
+	}
+}
+
+func TestWithMaxQueuedNotifications_NegativeIgnored(t *testing.T) {
+	c2aR, c2aW := io.Pipe()
+	a2cR, a2cW := io.Pipe()
+	t.Cleanup(func() {
+		_ = c2aR.Close()
+		_ = c2aW.Close()
+		_ = a2cR.Close()
+		_ = a2cW.Close()
+	})
+
+	client := &clientFuncs{}
+	csc := NewClientSideConnection(client, c2aW, a2cR, WithMaxQueuedNotifications(-5))
+
+	if cap(csc.conn.notificationQueue) != defaultMaxQueuedNotifications {
+		t.Fatalf("negative option should keep default: got %d, want %d", cap(csc.conn.notificationQueue), defaultMaxQueuedNotifications)
+	}
+}
+
+func TestLargerQueue_SurvivesNotificationBurst(t *testing.T) {
+	// With a tiny queue (2), a burst of notifications should overflow.
+	// With a larger queue, it should survive.
+	const burstSize = 50
+
+	var mu sync.Mutex
+	var received int
+
+	client := &clientFuncs{
+		SessionUpdateFunc: func(_ context.Context, n SessionNotification) error {
+			// Simulate slow processing
+			time.Sleep(time.Millisecond)
+			mu.Lock()
+			received++
+			mu.Unlock()
+			return nil
+		},
+	}
+
+	c2aR, c2aW := io.Pipe()
+	a2cR, a2cW := io.Pipe()
+	t.Cleanup(func() {
+		_ = c2aR.Close()
+		_ = c2aW.Close()
+		_ = a2cR.Close()
+		_ = a2cW.Close()
+	})
+
+	// Use a queue large enough to absorb the burst.
+	clientConn := NewClientSideConnection(client, c2aW, a2cR, WithMaxQueuedNotifications(burstSize*2))
+	agentConn := NewAgentSideConnection(agentFuncs{}, a2cW, c2aR, WithMaxQueuedNotifications(burstSize*2))
+
+	for i := 0; i < burstSize; i++ {
+		if err := agentConn.SessionUpdate(context.Background(), testSessionUpdate("burst", i)); err != nil {
+			t.Fatalf("SessionUpdate %d failed: %v", i, err)
+		}
+	}
+
+	// Wait for all notifications to be processed.
+	waitForNotificationBarrierDrain(t, clientConn.conn, 5*time.Second)
+
+	mu.Lock()
+	got := received
+	mu.Unlock()
+
+	if got != burstSize {
+		t.Fatalf("received %d notifications, want %d", got, burstSize)
+	}
+	_ = fmt.Sprintf("") // use fmt
+}


### PR DESCRIPTION
## Problem

When multiplexing many concurrent ACP sessions over a single connection (e.g., in a multi-session client like Mitto), the combined notification rate from all sessions (streaming chunks, tool calls, thoughts) can exceed the processing speed of the single-threaded notification consumer. This causes the hard-coded 1024-entry notification queue to overflow, which kills the entire connection with a `notification queue overflow` error.

In practice, with 5+ sessions actively streaming, we observed 20+ queue overflows per day. Each overflow kills the connection, forces a process restart, invalidates all in-flight auxiliary sessions (title generation, follow-up suggestions), and causes a cascade of failures.

## Solution

Introduce a functional options pattern for `NewConnection`, `NewClientSideConnection`, and `NewAgentSideConnection` via a new `ConnectionOption` type. The first option is `WithMaxQueuedNotifications(n int)`, which allows callers to increase the notification queue capacity beyond the default 1024.

### API

```go
// Default behavior (unchanged — backward compatible)
conn := acp.NewClientSideConnection(client, stdin, stdout)

// With larger queue for multiplexed connections
conn := acp.NewClientSideConnection(client, stdin, stdout,
    acp.WithMaxQueuedNotifications(8192))
```

### Changes

- **`connection.go`**: Added `ConnectionOption` functional options type, `connectionConfig` struct, and `WithMaxQueuedNotifications` option. `NewConnection` now accepts variadic `...ConnectionOption`.
- **`client.go`**: `NewClientSideConnection` now accepts and forwards `...ConnectionOption`.
- **`agent.go`**: `NewAgentSideConnection` now accepts and forwards `...ConnectionOption`.
- **`connection_queue_size_test.go`**: 6 new tests covering default size, custom size, agent-side, zero/negative guards, and a burst test proving a larger queue survives notification floods.

### Backward Compatibility

Fully backward compatible. All existing callers without options get exactly the same default behavior (1024). All existing tests pass unchanged.
